### PR TITLE
Fix: Persistencia del carrito con localStorage

### DIFF
--- a/src/stores/cartStore.ts
+++ b/src/stores/cartStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 import { CartItem, Product } from '../types';
 
-// Define la clave para sessionStorage
-const CART_STORAGE_KEY = 'cartState_v1';
+// Define la clave para localStorage
+const CART_STORAGE_KEY = 'cartState_v1_localStorage'; // Cambiado para evitar conflictos con sessionStorage anterior
 
 interface CartState {
   items: CartItem[];
@@ -18,33 +18,33 @@ interface CartStore extends CartState {
   toggleCart: () => void;
 }
 
-// Función para cargar el estado inicial desde sessionStorage
+// Función para cargar el estado inicial desde localStorage
 const loadState = (): CartState => {
   try {
-    const storedState = sessionStorage.getItem(CART_STORAGE_KEY);
+    const storedState = localStorage.getItem(CART_STORAGE_KEY);
     if (storedState) {
       const parsedState = JSON.parse(storedState);
       if (Array.isArray(parsedState.items) && typeof parsedState.total === 'number') {
-        console.log('cartStore: Loaded state from sessionStorage:', parsedState);
+        console.log('cartStore: Loaded state from localStorage:', parsedState);
         return parsedState;
       }
     }
   } catch (error) {
-    console.error('cartStore: Error loading state from sessionStorage:', error);
-    sessionStorage.removeItem(CART_STORAGE_KEY);
+    console.error('cartStore: Error loading state from localStorage:', error);
+    localStorage.removeItem(CART_STORAGE_KEY);
   }
-  console.log('cartStore: No valid state in sessionStorage, initializing with default.');
+  console.log('cartStore: No valid state in localStorage, initializing with default.');
   return { items: [], isOpen: false, total: 0 };
 };
 
-// Función para guardar el estado en sessionStorage
+// Función para guardar el estado en localStorage
 const saveState = (state: CartState) => {
   try {
     const stateToSave = { items: state.items, total: state.total, isOpen: state.isOpen };
-    sessionStorage.setItem(CART_STORAGE_KEY, JSON.stringify(stateToSave));
-    console.log('cartStore: Saved state to sessionStorage:', stateToSave);
+    localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(stateToSave));
+    console.log('cartStore: Saved state to localStorage:', stateToSave);
   } catch (error) {
-    console.error('cartStore: Error saving state to sessionStorage:', error);
+    console.error('cartStore: Error saving state to localStorage:', error);
   }
 };
 
@@ -57,7 +57,7 @@ export const useCartStore = create<CartStore>((set, get) => {
     toggleCart: () => {
       set((state) => {
         const newState = { ...state, isOpen: !state.isOpen };
-        saveState(newState);
+        saveState(newState); // Guardar estado también al cambiar visibilidad del carrito
         return { isOpen: !state.isOpen };
       });
     },
@@ -97,9 +97,9 @@ export const useCartStore = create<CartStore>((set, get) => {
       set((state) => {
         const items = state.items.map(item => 
           item.product.id === productId 
-            ? { ...item, quantity: Math.max(0, quantity) }
+            ? { ...item, quantity: Math.max(0, quantity) } // Evitar cantidades negativas
             : item
-        ).filter(item => item.quantity > 0);
+        ).filter(item => item.quantity > 0); // Eliminar items con cantidad 0
 
         const total = items.reduce((sum, item) => sum + (item.product.price * item.quantity), 0);
         const newState = { ...state, items, total };
@@ -109,10 +109,11 @@ export const useCartStore = create<CartStore>((set, get) => {
     },
 
     clearCart: () => {
-      console.log('cartStore: clearCart CALLED!'); // <--- LÍNEA AÑADIDA PARA DEPURACIÓN
+      console.log('cartStore: clearCart CALLED! Clearing localStorage.');
       set((state) => {
         const newState = { ...state, items: [], total: 0 };
-        saveState(newState);
+        saveState(newState); // Guardar el estado vacío
+        // localStorage.removeItem(CART_STORAGE_KEY); // Alternativamente, se puede remover la clave directamente
         return { items: [], total: 0 }; 
       });
     },
@@ -120,7 +121,6 @@ export const useCartStore = create<CartStore>((set, get) => {
 });
 
 // Opcional: Si necesitas una forma de recargar el estado manualmente desde fuera del store
-// (aunque con esta implementación, se carga al inicio automáticamente)
 // export const hydrateCartStore = () => {
 //   useCartStore.setState(loadState());
 // };


### PR DESCRIPTION
Se ha modificado cartStore.ts para utilizar localStorage en lugar de sessionStorage, con el objetivo de mejorar la persistencia del estado del carrito a través de redirecciones y cierres de pestaña.

Esto aborda el problema donde el carrito aparecía vacío después de la redirección desde Mercado Pago.

Instrucciones de prueba para el usuario incluidas en la notificación de la Pull Request.